### PR TITLE
Feat/search ep/parameters

### DIFF
--- a/src/JiraStub.kt
+++ b/src/JiraStub.kt
@@ -39,8 +39,16 @@ fun Application.module(testing: Boolean = false) {
                 }
                 get("search") {
                     val jql = call.parameters["jql"]
+                    var maxResults = call.parameters["maxResults"]
+                    var startAt = call.parameters["startAt"]
+                    if (maxResults==null) {
+                        maxResults="50"
+                    }
+                    if (startAt==null){
+                        startAt="0"
+                    }
                     jql?.let {
-                        call.respond(JiraServices().getSearchResultWith(jql))
+                        call.respond(JiraServices().getSearchResultWith(jql,maxResults,startAt))
                     } ?: run {
                         call.respond(HttpStatusCode.BadRequest)
                     }

--- a/src/jirastub/services/JiraServices.kt
+++ b/src/jirastub/services/JiraServices.kt
@@ -22,10 +22,10 @@ class JiraServices {
             active = true
         )
     }
-    fun getSearchResultWith(jql: String): SearchResult {
+    fun getSearchResultWith(jql: String, maxResults: String, startAt: String): SearchResult {
         return SearchResult(
-            startAt = 0,
-            maxResults = 50,
+            startAt = startAt.toInt(),
+            maxResults = maxResults.toInt(),
             total = 3,
             issues = listOf(
                 Ticket(

--- a/test/JiraStubTest.kt
+++ b/test/JiraStubTest.kt
@@ -51,6 +51,18 @@ class JiraStubTest {
                     response.content
                 )
             }
+            // Testing maxResults and startAt being passed in as parameters
+            handleRequest(HttpMethod.Get, "rest/api/2/search?jql=test&startAt=10&maxResults=40") {
+                addHeader(
+                    HttpHeaders.Authorization,
+                    HttpAuthHeader.Single("basic", Base64.getEncoder().encodeToString("$username:$password".toByteArray())).render()
+                )
+            }.apply {
+                assertEquals(
+                    """{"startAt":10,"maxResults":40,"total":3,"issues":[{"key":"ABC-1111","fields":{"summary":"A summary","status":{"name":"Status Name"},"issuetype":{"name":"Type name"},"customfield_10006":"ABC-1234","assignee":{"displayName":"Tony Foxbridge"},"duedate":"2020-01-01"}},{"key":"ABC-1111","fields":{"summary":"A summary","status":{"name":"Status Name"},"issuetype":{"name":"Type name"},"customfield_10006":"ABC-1234","assignee":{"displayName":"Tony Foxbridge"},"duedate":"2020-01-01"}},{"key":"ABC-1111","fields":{"summary":"A summary","status":{"name":"Status Name"},"issuetype":{"name":"Type name"},"customfield_10006":"ABC-1234","assignee":{"displayName":"Tony Foxbridge"},"duedate":"2020-01-01"}}]}""",
+                    response.content
+                )
+            }
         }
     }
 }

--- a/test/JiraStubTest.kt
+++ b/test/JiraStubTest.kt
@@ -51,7 +51,6 @@ class JiraStubTest {
                     response.content
                 )
             }
-            // Testing maxResults and startAt being passed in as parameters
             handleRequest(HttpMethod.Get, "rest/api/2/search?jql=test&startAt=10&maxResults=40") {
                 addHeader(
                     HttpHeaders.Authorization,


### PR DESCRIPTION
In the testGetSearchResultWith() I created a test to check when parameters are passed in but didn't create one for when there are no parameters passed and it uses the default of 0 and 50 for startAt and maxResults respectively, because the previous test that was already there covers that.